### PR TITLE
Fix broken live site links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ The sign-up page for the [Design Tokens Newsletter](https://designtokens.curated
 A list of company design systems Design Tokens section
 
 - [Salesforce Lightning Design System](https://www.lightningdesignsystem.com/design-tokens/)
-- [Formstack](https://www.formstack.com/brand/design-system/tokens)
-- [Comet (Discovery Education)](https://comet.discoveryeducation.com/resources/tokens.html)
+- [Formstack](https://www.formstack.com/brand/design-system/variables-colors)
+- [Comet (Discovery Education)](https://comet.discoveryeducation.com/visual-language/tokens.html)
 - [Kalo](https://kalo.design/foundations/design-tokens/)
 - [Hex (Bitnami)](https://design.bitnami.com/category/Design-Tokens/)
 - [Mineral UI](https://mineral-ui.netlify.com/tokens)


### PR DESCRIPTION
Two of the live site token pages appear to have moved.