### PR TITLE
Added Figma Design Tokens plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ A list of plugins to help you move tokens from apps to wherever you want
 - [Abstract Connect](https://github.com/MichaelZaporozhets/abstractconnect)
 - [Figmagic (Figma)](https://github.com/mikaelvesavuori/figmagic)
 - [Figgo (Figma)](https://github.com/B3nnyL/figgo)
+- [Design Tokens (Figma)](https://github.com/lukasoppermann/design-tokens)
 
 ## Slides, Videos, Podcasts
 


### PR DESCRIPTION
A plugin to export design tokens from Figma that are style dictionary compatible or to sync it with a github repo.