### PR TITLE
Add open source design token validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ A list of tools that help you generate other files from your design tokens
 - [Design tokens export plugin](https://github.com/design-meets-development/design-tokens-plugin)
 - [Design Tokens Generator](https://tokens.layoutit.com/)
 - another [Design Tokens Generator](https://www.design-tokens.dev)
+- [Design Tokens Validator](https://animaapp.github.io/design-token-validator-site/)
 
 ## Resources
 


### PR DESCRIPTION
Heya @sturobson !

I just created an open source [Design Token Validator](https://animaapp.github.io/design-token-validator-site/) that adheres to the working group's spec.

I think it'd make a great addition to your awesome list as I don't see anything similar presently